### PR TITLE
Fix Redis configuration in production Docker Compose files

### DIFF
--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -2,6 +2,19 @@
 # Use: docker compose -f docker-compose.debug.yml up
 
 services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   pdf-translator:
     build: 
       context: .
@@ -19,12 +32,15 @@ services:
       - PDF_TRANSLATE_DEBUG=true
       - PDF_TRANSLATE_HOST=0.0.0.0
       - PDF_TRANSLATE_PORT=8000
-      - PDF_TRANSLATE_REDIS_URL=redis://localhost:6379/0
+      - PDF_TRANSLATE_REDIS_URL=redis://redis:6379/0
       - PDF_TRANSLATE_DATABASE_URL=sqlite:///./data/jobs.db
       - PDF_TRANSLATE_MODEL_NAME=facebook/mbart-large-50-many-to-many-mmt
       - PDF_TRANSLATE_USE_SAFETENSORS=true
       - PDF_TRANSLATE_CPU_LOAD_THEN_GPU=false
       - PDF_TRANSLATE_MAX_TOKENS_PER_BATCH=32000
+    depends_on:
+      redis:
+        condition: service_healthy
     restart: unless-stopped
     command: ["debug"]  # Start in debug mode
     healthcheck:
@@ -35,5 +51,7 @@ services:
       start_period: 120s
 
 volumes:
+  redis_data:
+    driver: local
   model_cache:
     driver: local

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -3,6 +3,20 @@
 # Requires: NVIDIA Docker runtime
 
 services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
   pdf-translator:
     build: 
       context: .
@@ -20,7 +34,7 @@ services:
       - PDF_TRANSLATE_DEBUG=false
       - PDF_TRANSLATE_HOST=0.0.0.0
       - PDF_TRANSLATE_PORT=8000
-      - PDF_TRANSLATE_REDIS_URL=redis://localhost:6379/0
+      - PDF_TRANSLATE_REDIS_URL=redis://redis:6379/0
       - PDF_TRANSLATE_DATABASE_URL=sqlite:///./data/jobs.db
       - PDF_TRANSLATE_MODEL_NAME=facebook/nllb-200-3.3B
       - PDF_TRANSLATE_MODEL_REVISION=refs/pr/17
@@ -29,6 +43,9 @@ services:
       - PDF_TRANSLATE_MAX_TOKENS_PER_BATCH=64000
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    depends_on:
+      redis:
+        condition: service_healthy
     deploy:
       resources:
         reservations:
@@ -45,5 +62,7 @@ services:
       start_period: 120s
 
 volumes:
+  redis_data:
+    driver: local
   model_cache:
     driver: local

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,6 +2,20 @@
 # Use: docker compose -f docker-compose.prod.yml up -d
 
 services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
   pdf-translator:
     build: 
       context: .
@@ -19,12 +33,15 @@ services:
       - PDF_TRANSLATE_DEBUG=true
       - PDF_TRANSLATE_HOST=0.0.0.0
       - PDF_TRANSLATE_PORT=8000
-      - PDF_TRANSLATE_REDIS_URL=redis://localhost:6379/0
+      - PDF_TRANSLATE_REDIS_URL=redis://redis:6379/0
       - PDF_TRANSLATE_DATABASE_URL=sqlite:///./data/jobs.db
       - PDF_TRANSLATE_MODEL_NAME=facebook/mbart-large-50-many-to-many-mmt
       - PDF_TRANSLATE_USE_SAFETENSORS=true
       - PDF_TRANSLATE_CPU_LOAD_THEN_GPU=true
       - PDF_TRANSLATE_MAX_TOKENS_PER_BATCH=64000
+    depends_on:
+      redis:
+        condition: service_healthy
     deploy:
       resources:
         reservations:
@@ -41,5 +58,7 @@ services:
       start_period: 120s
 
 volumes:
+  redis_data:
+    driver: local
   model_cache:
     driver: local


### PR DESCRIPTION
## Problem

When deploying the container with `./scripts/deploy.sh deploy`, Redis was not working inside the container, causing job queue failures and preventing the translation service from processing background jobs.

## Root Cause

The production Docker Compose files (`docker-compose.prod.yml`, `docker-compose.gpu.yml`, and `docker-compose.debug.yml`) were missing the Redis service definition, but the application was configured to connect to Redis at `redis://localhost:6379/0`. This caused connection failures since no Redis instance was running.

## Solution

This PR adds proper Redis configuration to all production-related Docker Compose files:

### Changes Made

1. **Added Redis service definition**:
   - Uses `redis:7-alpine` image for consistency with development setup
   - Configured with persistent data storage using Docker volumes
   - Added health checks for proper startup ordering
   - Included restart policy for reliability

2. **Updated Redis connection URL**:
   - Changed from `redis://localhost:6379/0` to `redis://redis:6379/0`
   - Uses Docker's internal networking to connect to the Redis service

3. **Added service dependencies**:
   - Application now waits for Redis to be healthy before starting
   - Prevents connection failures during startup

4. **Added Redis data volume**:
   - Ensures Redis data persistence across container restarts

### Files Updated

- ✅ `docker-compose.prod.yml` - Production configuration
- ✅ `docker-compose.gpu.yml` - GPU-enabled production configuration  
- ✅ `docker-compose.debug.yml` - Debug configuration

### What Redis is Used For

Redis is essential for the application's job queue system:
- **Job Queue Management**: Using RQ (Redis Queue) for background translation jobs
- **Job Status Tracking**: Storing job progress and status information
- **Worker Communication**: Coordinating between the web application and worker processes

## Testing

After this fix, `./scripts/deploy.sh deploy` should:
1. Start Redis first and wait for it to be healthy
2. Start the application which can now successfully connect to Redis
3. Enable job queuing for PDF translation tasks
4. Allow worker processes to process translation jobs

## Verification

To verify the fix works:
```bash
# Check service status
./scripts/deploy.sh status

# Check logs for Redis connectivity
./scripts/deploy.sh logs pdf-translator

# Look for successful Redis connection messages
```

Fixes the Redis connectivity issue reported in production deployments.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author